### PR TITLE
Use system compiler linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ cmake_minimum_required (VERSION 2.8)
 include(ExternalProject)
 
 ## Needs ITK at least v4
-find_package(ITK REQUIRED NO_DEFAULT_PATH)
+find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 if( "${ITK_VERSION_MAJOR}" LESS 4 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,11 +103,11 @@ if(NOT MSVC)
     set(COMMON_LIBS ${COMMON_LIBS} stdc++)  # not sure why we need stdc++ here
 endif()
 
-add_executable( test test.cpp slic/LKM.cpp slic/utils.cpp )
+add_executable( _test test.cpp slic/LKM.cpp slic/utils.cpp )
 if (APPLE OR MSVC)
-    target_link_libraries( test ${COMMON_LIBS} )
+    target_link_libraries( _test ${COMMON_LIBS} )
 else()
-    target_link_libraries( test ${COMMON_LIBS} rt)
+    target_link_libraries( _test ${COMMON_LIBS} rt)
 endif()
 
 #

--- a/conda-recipe/build.sh
+++ b/conda-recipe/build.sh
@@ -17,7 +17,10 @@ else
     CC=gcc
     CXX=g++
     IIBOOST_USE_OPENMP=YES
-    IIBOOST_CXXFLAGS="${IIBOOST_CXXFLAGS} -D_GLIBCXX_USE_CXX11_ABI=0"
+    # enable compilation without CXX abi to stay compatible with gcc < 5 built packages
+    if [[ ${DO_NOT_BUILD_WITH_CXX11_ABI} == '1' ]]; then
+        IIBOOST_CXXFLAGS="-D_GLIBCXX_USE_CXX11_ABI=0 ${IIBOOST_CXXFLAGS}"
+    fi
 fi
 
 mkdir build

--- a/conda-recipe/build.sh
+++ b/conda-recipe/build.sh
@@ -14,9 +14,10 @@ if [[ $(uname) == 'Darwin' ]]; then
     IIBOOST_USE_OPENMP=NO # clang trunk supports -fopenmp, but Apple's clang doesn't support it yet.
 else
     DYLIB_EXT=so
-    CC=${PREFIX}/bin/gcc
-    CXX=${PREFIX}/bin/g++
+    CC=gcc
+    CXX=g++
     IIBOOST_USE_OPENMP=YES
+    IIBOOST_CXXFLAGS="${IIBOOST_CXXFLAGS} -D_GLIBCXX_USE_CXX11_ABI=0"
 fi
 
 mkdir build

--- a/conda-recipe/build.sh
+++ b/conda-recipe/build.sh
@@ -37,7 +37,6 @@ cmake .. \
     -DPYTHON_INCLUDE_PATH=${PREFIX}/include/python${PY_ABI} \
     -DPYTHON_LIBRARIES=${PREFIX}/lib/libpython${PY_ABI}.${DYLIB_EXT} \
     -DPYTHON_NUMPY_INCLUDE_DIR=${SP_DIR}/numpy/core/include \
-    -DITK_DIR=${PREFIX}/lib/cmake/ITK-4.11 \
     -DIIBOOST_USE_OPENMP=${IIBOOST_USE_OPENMP} \
 ##
 

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -24,18 +24,20 @@ requirements:
   build:
     - python 2.7*|>=3.5
     - python {{PY_VER}}*
-    - numpy
-    - itk 4.11*
+    - numpy {{NPY_VER}}*
+    - itk
     - jpeg
+    - libitk
     - libtiff
     - hdf5 1.10.1
     - libpng 1.6.28
 
   run:
     - python {{PY_VER}}*
-    - numpy
-    - itk 4.11*
+    - numpy {{NPY_VER}}*
+    - itk
     - jpeg
+    - libitk
     - libtiff
     - libpng >=1.6.28
     - hdf5 1.10.1

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -16,7 +16,7 @@ source:
   path: ..
 
 build:
-  number: 0
+  number: 1
   string: {{CONDA_PY}}_{{PKG_BUILDNUM}}_g{{GIT_FULL_HASH[:7]}}
   detect_binary_files_with_prefix: true
   script_env:

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -16,7 +16,7 @@ source:
   path: ..
 
 build:
-  number: 1
+  number: 2
   string: {{CONDA_PY}}_{{PKG_BUILDNUM}}_g{{GIT_FULL_HASH[:7]}}
   detect_binary_files_with_prefix: true
   script_env:
@@ -41,6 +41,8 @@ requirements:
     - itk
     - jpeg
     - libitk
+    # in order to suppor older linux distros after gcc5 switch:
+    - libstdcxx-ng >=5.4.0
     - libtiff
     - libpng >=1.6.28
     - hdf5 1.10.1

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -22,7 +22,6 @@ build:
 
 requirements:  
   build:
-    - gcc 4.8.5 # [linux]
     - python 2.7*|>=3.5
     - python {{PY_VER}}*
     - numpy
@@ -33,7 +32,6 @@ requirements:
     - libpng 1.6.28
 
   run:
-    - libgcc # [linux]
     - python {{PY_VER}}*
     - numpy
     - itk 4.11*

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -19,6 +19,9 @@ build:
   number: 0
   string: {{CONDA_PY}}_{{PKG_BUILDNUM}}_g{{GIT_FULL_HASH[:7]}}
   detect_binary_files_with_prefix: true
+  script_env:
+    # Control building with CXX11 abi
+    - DO_NOT_BUILD_WITH_CXX11_ABI  # [linux]
 
 requirements:  
   build:

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -28,7 +28,7 @@ requirements:
     - itk 4.11*
     - jpeg
     - libtiff
-    - hdf5 1.8.17
+    - hdf5 1.10.1
     - libpng 1.6.28
 
   run:
@@ -38,7 +38,7 @@ requirements:
     - jpeg
     - libtiff
     - libpng >=1.6.28
-    - hdf5 1.8.17
+    - hdf5 1.10.1
 
 test:
   imports:


### PR DESCRIPTION
This is related to allowing dependencies to be built with newer gcc than the one available through conda (4.8.5 atm), in particular, recent nifty changes forced us to use a newer compiler.

See some more background on this in https://github.com/ilastik/ilastik-publish-packages/issues/2

In order to use the system compilers this PR removes

* fixed naming of test package
* added libitk requirement
* references to `gcc`, `libgcc` in the respective `meta.yaml` files
* points to the correct compiler in `build.sh`
* introduces an environment variable `DO_NOT_BUILD_WITH_CXX11_ABI` that is used in the build process to enable building with `-D_GLIBCXX_USE_CXX11_ABI=0` to enable compatibility with the "old" gcc stdlib abi.